### PR TITLE
Update integration.yml to remove Drupal 8.9

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -20,8 +20,6 @@ jobs:
       matrix:
         include:
           - php-version: "7.4"
-            drupal-version: "~8.9"
-          - php-version: "7.4"
             drupal-version: "^9"
           - php-version: "8.0"
             drupal-version: "^9"


### PR DESCRIPTION
Removed Drupal version 8.9 from the CI matrix.